### PR TITLE
fix: enforce image size limits server-side

### DIFF
--- a/claude-agent-demo/app/api/chat/route.ts
+++ b/claude-agent-demo/app/api/chat/route.ts
@@ -18,6 +18,16 @@ const MAX_TOTAL_IMAGE_BYTES = 15 * 1024 * 1024; // 15MB combined
 const THINKING_MIN_BUDGET = 1_024;
 const THINKING_MAX_BUDGET = 64_000;
 
+/**
+ * Calculate the actual decoded size of a base64 string.
+ * Base64 encodes 3 bytes into 4 characters, so decoded size ≈ length * 3/4.
+ * Padding characters (=) don't contribute to decoded bytes.
+ */
+function getBase64DecodedSize(base64: string): number {
+  const padding = (base64.match(/=+$/) || [''])[0].length;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
 const imageSchema = z.object({
   id: z.string().min(1),
   mimeType: z
@@ -30,8 +40,15 @@ const imageSchema = z.object({
     .number()
     .int()
     .positive()
-    .max(MAX_IMAGE_BYTES, `Images must be ${MAX_IMAGE_BYTES / (1024 * 1024)}MB or smaller`)
-});
+}).refine(
+  (img) => {
+    const actualSize = getBase64DecodedSize(img.base64);
+    return actualSize <= MAX_IMAGE_BYTES;
+  },
+  {
+    message: `Images must be ${MAX_IMAGE_BYTES / (1024 * 1024)}MB or smaller`,
+  }
+);
 
 const thinkingSchema = z.object({
   enabled: z.boolean(),
@@ -65,7 +82,8 @@ export async function POST(req: NextRequest) {
   const images = payload.body.images ?? [];
   const mode: ToolMode = payload.body.toolMode ?? 'safe';
   const trimmed = message.trim();
-  const totalImageBytes = images.reduce((sum, img) => sum + img.size, 0);
+  // Calculate actual payload size server-side instead of trusting client-reported size
+  const totalImageBytes = images.reduce((sum, img) => sum + getBase64DecodedSize(img.base64), 0);
   const thinkingConfig = thinking?.enabled ? thinking : undefined;
 
   if (!trimmed && images.length === 0) {

--- a/claude-agent-demo/app/api/chat/route.ts
+++ b/claude-agent-demo/app/api/chat/route.ts
@@ -40,6 +40,7 @@ const imageSchema = z.object({
     .number()
     .int()
     .positive()
+    .optional()
 }).refine(
   (img) => {
     const actualSize = getBase64DecodedSize(img.base64);


### PR DESCRIPTION
## Summary
Fixes a potential DoS vulnerability where the API trusted client-supplied `size` field when enforcing image upload limits.

## Problem
The API validated the client-reported `size` field (5MB per image, 15MB total) but never verified the actual `base64` payload length. A malicious client could set `size: 1` while posting arbitrarily large base64 blobs, bypassing all limits and risking memory/CPU exhaustion.

## Solution
This PR:
1. **Adds `getBase64DecodedSize()`** - Accurately calculates decoded payload size from base64 string length, accounting for padding
2. **Updates `imageSchema`** - Uses Zod's `refine()` to validate actual payload size instead of trusting client-reported `size`
3. **Fixes total size calculation** - Uses actual payload sizes when checking combined 15MB limit

## Changes
- `claude-agent-demo/app/api/chat/route.ts`: Add server-side base64 size calculation and validation

## Testing
The fix can be verified by:
1. Sending a request with `size: 1` but a large base64 payload (>5MB)
2. The server should now reject with "Images must be 5MB or smaller"

Closes #4