### PR TITLE
Preserve OpenRouter upstream error details

### DIFF
--- a/worker/src/errors.ts
+++ b/worker/src/errors.ts
@@ -34,9 +34,13 @@ export function rateLimitError(message: string, details?: Record<string, unknown
   return new CastariError(429, 'rate_limit_error', message, { retryable: true, details });
 }
 
-export function upstreamError(status: number, message: string): CastariError {
+export function upstreamError(
+  status: number,
+  message: string,
+  details?: Record<string, unknown>,
+): CastariError {
   const type = status >= 500 ? 'api_error' : 'invalid_request_error';
-  return new CastariError(status, type, message, { retryable: status >= 500 });
+  return new CastariError(status, type, message, { retryable: status >= 500, details });
 }
 
 export function errorResponse(error: unknown): Response {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,6 +1,11 @@
 import { resolveConfig, Env } from './config';
-import { errorResponse, authenticationError, invalidRequest } from './errors';
-import { normalizeCastariHeaders, readJsonBody } from './utils';
+import {
+  errorResponse,
+  authenticationError,
+  invalidRequest,
+  upstreamError,
+} from './errors';
+import { normalizeCastariHeaders, readJsonBody, isJsonMime } from './utils';
 import { categorizeServerTools, detectServerTools, resolveProvider } from './provider';
 import { buildOpenRouterRequest, mapOpenRouterResponse } from './translator';
 import { streamOpenRouterToAnthropic } from './stream';
@@ -9,6 +14,7 @@ import {
   AnthropicResponse,
   CastariMetadata,
   CastariReasoningConfig,
+  OpenRouterResponse,
   WebSearchOptions,
   WorkerConfig,
 } from './types';
@@ -59,10 +65,10 @@ export default {
       }
 
       if (provider === 'anthropic') {
-        return proxyAnthropic(body, request, authHeader.value, config.anthropicBaseUrl);
+        return await proxyAnthropic(body, request, authHeader.value, config.anthropicBaseUrl);
       }
 
-      return handleOpenRouter({
+      return await handleOpenRouter({
         body,
         wireModel,
         originalModel,
@@ -153,16 +159,23 @@ async function handleOpenRouter(ctx: OpenRouterContext): Promise<Response> {
 
   if (ctx.body.stream) {
     if (!upstreamResp.ok) {
-      const payload = await upstreamResp.text();
-      throw invalidRequest('OpenRouter streaming error', { status: upstreamResp.status, body: payload });
+      throw upstreamError(
+        upstreamResp.status,
+        'OpenRouter streaming error',
+        await readUpstreamErrorDetails(upstreamResp),
+      );
     }
     return streamOpenRouterToAnthropic(upstreamResp, { originalModel: ctx.originalModel });
   }
 
-  const json = await upstreamResp.json();
   if (!upstreamResp.ok) {
-    throw invalidRequest('OpenRouter error', { status: upstreamResp.status, body: json });
+    throw upstreamError(
+      upstreamResp.status,
+      'OpenRouter error',
+      await readUpstreamErrorDetails(upstreamResp),
+    );
   }
+  const json = (await upstreamResp.json()) as OpenRouterResponse;
   const responseBody: AnthropicResponse = mapOpenRouterResponse(json, ctx.originalModel);
   return new Response(JSON.stringify(responseBody), {
     status: 200,
@@ -171,4 +184,26 @@ async function handleOpenRouter(ctx: OpenRouterContext): Promise<Response> {
       'cache-control': 'no-store',
     },
   });
+}
+
+async function readUpstreamErrorDetails(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let body: unknown = text;
+  if (text && isJsonMime(response.headers.get('content-type'))) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+
+  const details: Record<string, unknown> = {
+    status: response.status,
+    body,
+  };
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) details.retryAfter = retryAfter;
+  return details;
 }

--- a/worker/src/translator.ts
+++ b/worker/src/translator.ts
@@ -2,6 +2,8 @@ import {
   AnthropicContent,
   AnthropicContentImage,
   AnthropicContentText,
+  AnthropicContentToolResult,
+  AnthropicContentToolUse,
   AnthropicMessage,
   AnthropicRequest,
   AnthropicResponse,
@@ -78,8 +80,8 @@ function convertMessage(message: AnthropicMessage): OpenRouterMessage[] {
     ? message.content
     : [{ type: 'text', text: message.content } as AnthropicContentText];
   const textSegments: AnthropicContent[] = [];
-  const toolResults: AnthropicContent[] = [];
-  const toolUses: AnthropicContent[] = [];
+  const toolResults: AnthropicContentToolResult[] = [];
+  const toolUses: AnthropicContentToolUse[] = [];
 
   for (const segment of segments) {
     if (!segment || typeof segment !== 'object') continue;

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import worker from '../src/index';
+import { Env } from '../src/config';
+
+const env: Env = {
+  UPSTREAM_OPENROUTER_BASE_URL: 'https://openrouter.test/api',
+  OPENROUTER_DEFAULT_VENDOR: 'openai',
+};
+
+function openRouterRequest(stream: boolean): Request {
+  return new Request('https://worker.test/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': 'test-key',
+      'x-castari-provider': 'openrouter',
+    },
+    body: JSON.stringify({
+      model: 'or:gpt-5-mini',
+      max_tokens: 32,
+      stream,
+      messages: [{ role: 'user', content: 'hello' }],
+    }),
+  });
+}
+
+describe('OpenRouter upstream errors', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves non-stream upstream status for non-JSON errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html>temporarily unavailable</html>', {
+          status: 503,
+          headers: {
+            'content-type': 'text/html',
+            'retry-after': '7',
+          },
+        }),
+      ),
+    );
+
+    const response = await worker.fetch(openRouterRequest(false), env);
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      type: 'api_error',
+      message: 'OpenRouter error',
+      retryable: true,
+      details: {
+        status: 503,
+        body: '<html>temporarily unavailable</html>',
+        retryAfter: '7',
+      },
+    });
+  });
+
+  it('preserves streaming upstream status and JSON details', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
+          status: 429,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '30',
+          },
+        }),
+      ),
+    );
+
+    const response = await worker.fetch(openRouterRequest(true), env);
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(429);
+    expect(body).toMatchObject({
+      type: 'invalid_request_error',
+      message: 'OpenRouter streaming error',
+      retryable: false,
+      details: {
+        status: 429,
+        body: { error: { message: 'rate limited' } },
+        retryAfter: '30',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix OpenRouter streaming errors so upstream 401/429/5xx statuses are preserved instead of being flattened through `invalidRequest()`
- fix non-stream OpenRouter errors by checking `ok` before parsing the success JSON path, so HTML/text error bodies do not turn into generic 500s
- include upstream error body and `Retry-After` in structured error details for client retry/debug logic
- add worker tests for non-stream text/html 503s and streaming JSON 429s
- narrow Anthropic tool-result/tool-use arrays so `tsc --noEmit` passes

Fixes #2 and #3.

## Test plan
- `cd worker && npm test -- --run`
- `cd worker && npm exec tsc -- --noEmit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OpenRouter upstream status codes and error bodies for streaming and non-stream requests, instead of flattening into generic errors. Adds structured details (including Retry-After) to support accurate client retries and debugging.

- **Bug Fixes**
  - Preserve upstream 401/429/5xx for streaming and non-stream; no flattening via invalidRequest.
  - Safely handle JSON or text/html error bodies and include upstream body + Retry-After in error details.
  - Add tests for 503 text/html and 429 streaming JSON; narrow tool-use/tool-result types so tsc passes.

<sup>Written for commit 0d778ea6c8172ddfb536cf52189d65ce085fbbc7. Summary will update on new commits. <a href="https://cubic.dev/pr/castari/castari-proxy/pull/7?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

